### PR TITLE
Bump flexi_logger version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::debugging"]
 
 [dependencies]
 chrono = "0.4.23"
-flexi_logger = { version = "0.25", default-features = false }
+flexi_logger = { version = "0.27.3", default-features = false }
 log = { version = "0.4", features = ["std"] }
 syslog = { version = "6.0" }
 


### PR DESCRIPTION
For some reason, this was needed for my code to compile.

The issue I was running into was:

```
error[E0277]: the trait bound `flexi_syslog::LogWriter<LoggerBackend>: flexi_logger::writers::LogWriter` is not satisfied
  --> src/bin/carbonadod.rs:78:28
   |
78 |             .log_to_writer(Box::new(syslog_writer));
   |                            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `flexi_logger::writers::LogWriter` is not implemented for `flexi_syslog::LogWriter<LoggerBackend>`
   |
   = help: the trait `flexi_logger::writers::LogWriter` is implemented for `FileLogWriter`
   = note: required for the cast from `Box<flexi_syslog::LogWriter<LoggerBackend>>` to `Box<(dyn flexi_logger::writers::LogWriter + 'static)>`
```